### PR TITLE
add hover delay to allow diagonal moves without changing category

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -676,6 +676,7 @@ const PanelMenuButton = new Lang.Class({
 
         this._applicationsViewMode = settings.get_enum('startup-view-mode');
         this._appGridColumns = settings.get_int('apps-grid-column-count');
+        this._hoverTimeoutId = 0;
         this._searchTimeoutId = 0;
         this._searchIconClickedId = 0;
         this._selectedItemIndex = null;
@@ -2554,11 +2555,18 @@ const PanelMenuButton = new Lang.Class({
         let allAppCategory = new CategoryListButton('all', _('All Applications'));
         if (settings.get_enum('category-selection-method') == SelectMethod.HOVER ) {
             allAppCategory.actor.connect('enter-event', Lang.bind(this, function() {
-                this._selectCategory(allAppCategory);
-                this.selectedAppTitle.set_text(allAppCategory.label.get_text());
-                this.selectedAppDescription.set_text('');
+                this.hoverDelay = settings.get_int('category-hover-delay');
+                this._hoverTimeoutId = Mainloop.timeout_add((this.hoverDelay >0) ? this.hoverDelay : 0, Lang.bind(this, function() {
+                    this._selectCategory(allAppCategory);
+                    this.selectedAppTitle.set_text(allAppCategory.label.get_text());
+                    this.selectedAppDescription.set_text('');
+                    this._hoverTimeoutId = 0;
+                }));
             }));
             allAppCategory.actor.connect('leave-event', Lang.bind(this, function() {
+                if (this._hoverTimeoutId > 0) {
+                    Mainloop.source_remove(this._hoverTimeoutId);
+                }
                 this.selectedAppTitle.set_text('');
                 this.selectedAppDescription.set_text('');
             }));
@@ -2591,11 +2599,18 @@ const PanelMenuButton = new Lang.Class({
         let freqAppCategory = new CategoryListButton('frequent', _('Frequent Apps'));
         if (settings.get_enum('category-selection-method') == SelectMethod.HOVER ) {
             freqAppCategory.actor.connect('enter-event', Lang.bind(this, function() {
-                this._selectCategory(freqAppCategory);
-                this.selectedAppTitle.set_text(freqAppCategory.label.get_text());
-                this.selectedAppDescription.set_text('');
+                this.hoverDelay = settings.get_int('category-hover-delay');
+                this._hoverTimeoutId = Mainloop.timeout_add((this.hoverDelay >0) ? this.hoverDelay : 0, Lang.bind(this, function() {
+                    this._selectCategory(freqAppCategory);
+                    this.selectedAppTitle.set_text(freqAppCategory.label.get_text());
+                    this.selectedAppDescription.set_text('');
+                    this._hoverTimeoutId = 0;
+                 }));
             }));
             freqAppCategory.actor.connect('leave-event', Lang.bind(this, function() {
+                if (this._hoverTimeoutId > 0) {
+                    Mainloop.source_remove(this._hoverTimeoutId);
+                }
                 this.selectedAppTitle.set_text('');
                 this.selectedAppDescription.set_text('');
             }));
@@ -2628,11 +2643,18 @@ const PanelMenuButton = new Lang.Class({
         let favAppCategory = new CategoryListButton('favorites', _('Favorite Apps'));
         if (settings.get_enum('category-selection-method') == SelectMethod.HOVER ) {
             favAppCategory.actor.connect('enter-event', Lang.bind(this, function() {
-                this._selectCategory(favAppCategory);
-                this.selectedAppTitle.set_text(favAppCategory.label.get_text());
-                this.selectedAppDescription.set_text('');
+                this.hoverDelay = settings.get_int('category-hover-delay');
+                this._hoverTimeoutId = Mainloop.timeout_add((this.hoverDelay >0) ? this.hoverDelay : 0, Lang.bind(this, function() {
+                    this._selectCategory(favAppCategory);
+                    this.selectedAppTitle.set_text(favAppCategory.label.get_text());
+                    this.selectedAppDescription.set_text('');
+                    this._hoverTimeoutId = 0;
+                }));
             }));
             favAppCategory.actor.connect('leave-event', Lang.bind(this, function() {
+                if (this._hoverTimeoutId > 0) {
+                    Mainloop.source_remove(this._hoverTimeoutId);
+                }
                 this.selectedAppTitle.set_text('');
                 this.selectedAppDescription.set_text('');
             }));
@@ -2677,11 +2699,18 @@ const PanelMenuButton = new Lang.Class({
                     let appCategory = new CategoryListButton(dir);
                     if (settings.get_enum('category-selection-method') == SelectMethod.HOVER) {
                         appCategory.actor.connect('enter-event', Lang.bind(this, function() {
-                            this._selectCategory(appCategory);
-                            this.selectedAppTitle.set_text(appCategory.label.get_text());
-                            this.selectedAppDescription.set_text('');
+                            this.hoverDelay = settings.get_int('category-hover-delay');
+                            this._hoverTimeoutId = Mainloop.timeout_add((this.hoverDelay >0) ? this.hoverDelay : 0, Lang.bind(this, function() {
+                                this._selectCategory(appCategory);
+                                this.selectedAppTitle.set_text(appCategory.label.get_text());
+                                this.selectedAppDescription.set_text('');
+                                this._hoverTimeoutId = 0;
+                            }));
                         }));
                         appCategory.actor.connect('leave-event', Lang.bind(this, function() {
+                            if (this._hoverTimeoutId > 0) {
+                                Mainloop.source_remove(this._hoverTimeoutId);
+                            }
                             this.selectedAppTitle.set_text('');
                             this.selectedAppDescription.set_text('');
                         }));

--- a/prefs.js
+++ b/prefs.js
@@ -727,6 +727,35 @@ const GnoMenuPreferencesWidget = new GObject.Class({
         categorySelectMethodBox.add(categorySelectMethodCombo);
 
 
+        let hoverDelays = [0, 100, 150, 175, 200, 250, 400];
+        let categoryHoverDelayBox = new Gtk.Box({
+            spacing: 20,
+            orientation: Gtk.Orientation.HORIZONTAL,
+            homogeneous: false,
+            margin_left: 20,
+            margin_top: 5,
+            margin_bottom: 5,
+            margin_right: 10
+        });
+        let categoryHoverDelayLabel = new Gtk.Label({label: _("Menu hover delay"), hexpand:true, xalign:0});
+        let categoryHoverDelayCombo = new Gtk.ComboBoxText({halign:Gtk.Align.END});
+            categoryHoverDelayCombo.set_size_request(120, -1);
+            categoryHoverDelayCombo.append_text(_('0'));
+            categoryHoverDelayCombo.append_text(_('100'));
+            categoryHoverDelayCombo.append_text(_('150'));
+            categoryHoverDelayCombo.append_text(_('175'));
+            categoryHoverDelayCombo.append_text(_('200'));
+            categoryHoverDelayCombo.append_text(_('250'));
+            categoryHoverDelayCombo.append_text(_('400'));
+            categoryHoverDelayCombo.set_active(hoverDelays.indexOf(this.settings.get_int('category-hover-delay')));
+            categoryHoverDelayCombo.connect('changed', Lang.bind (this, function(widget) {
+                    this.settings.set_int('category-hover-delay', hoverDelays[widget.get_active()]);
+            }));
+
+        categoryHoverDelayBox.add(categoryHoverDelayLabel);
+        categoryHoverDelayBox.add(categoryHoverDelayCombo);
+
+
         let iconSizes = [16, 22, 24, 32, 48, 64];
 
         let favoritesIconSizeBox = new Gtk.Box({
@@ -816,6 +845,7 @@ const GnoMenuPreferencesWidget = new GObject.Class({
 
         appsSettings.add(hideCategoriesBox);
         appsSettings.add(categorySelectMethodBox);
+        appsSettings.add(categoryHoverDelayBox);
 
         appsSettings.add(startupAppsDisplayBox);
         appsSettings.add(startupViewModeBox);

--- a/schemas/org.gnome.shell.extensions.gnomenu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.gnomenu.gschema.xml
@@ -154,9 +154,14 @@
       <description>Hide the Categories Panel of the menu</description>
     </key>
     <key enum="org.gnome.shell.extensions.gnomenu.selectMethod" name="category-selection-method">
-      <default>'Click'</default>
+      <default>'Hover'</default>
       <summary>Method of selecting categories</summary>
       <description>Method of selecting categories</description>
+    </key>
+    <key type="i" name="category-hover-delay">
+      <default>150</default>
+      <summary>Delay (ms) before selecting category</summary>
+      <description>Delay in milliseconds before the category is selected when hovering</description>
     </key>
     <key type="i" name="shortcuts-icon-size">
       <default>32</default>


### PR DESCRIPTION
Many newer users have less-than-ideal mouse dexterity.  Requiring a
brief pause before changing the application category is really nice.
It is even nice for power users who can mouse directly/diagonally towards their
desired application without it disappearing on them when the
category changes as the cursor skips over a different category button.
With this change, using Hover as a default is preferable to Click.

The default of 150 requires a very brief pause. It might be too
fast for beginners, but should be acceptable for power users.  250
should be a pretty good number for newbies.  Don't forget to recompile
the schema.