### PR TITLE
Removes text label if empty.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -821,10 +821,12 @@ const PanelMenuButton = new Lang.Class({
 
         // Add label to button
         let labelText = settings.get_strv('panel-menu-label-text')[0];
-        let label = new St.Label({ text: ' '+labelText});
-        let labelWrapper = new St.Bin();
-        labelWrapper.set_child(label);
-        this._box.add(labelWrapper, {expand: true, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+        if (labelText.length > 0) {
+            let label = new St.Label({ text: ' '+labelText});
+            let labelWrapper = new St.Bin();
+            labelWrapper.set_child(label);
+            this._box.add(labelWrapper, {expand: true, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+        }
 
         // Add arrow to button
         this._box.add(PopupMenu.arrowIcon(St.Side.BOTTOM));


### PR DESCRIPTION
I moddified the extension so that the menu button is more compact when no text label is entered.

This is especially important if the dropdown arrows are removed (for example with this extension: https://extensions.gnome.org/extension/800/remove-dropdown-arrows/). Then the proportions of the button would look odd without my changes.

Before / After with Dropdown:
![with-dropdown](https://user-images.githubusercontent.com/515860/27184753-5926e482-51e3-11e7-9405-311080ff8bf1.png)

Before / After without Dropdown:
![without-dropdown](https://user-images.githubusercontent.com/515860/27184772-670d3dc6-51e3-11e7-8333-9b3c9c4697aa.png)
