### PR TITLE
Gnome 3.38 support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -128,6 +128,17 @@ Gtk.IconTheme.get_default = function() {
     return theme;
 };
 
+// Make sure that signals are handled and disconnected properly
+function disconnect(obj, sig) {
+    try {
+        if (sig != null && obj) {
+            obj.disconnect(sig);
+        }
+    } catch (error) {
+        log('[GnoMenu] Failed to disconnect signal: ' + error);
+    }
+}
+
 /* =========================================================================
 /* name:    SearchWebBookmarks
  * @desc    Class to consolodate search of web browser(s) bookmarks
@@ -3910,28 +3921,28 @@ var GnoMenuButton = class GnoMenu_GnoMenuPanelButton {
     destroy() {
         // Disconnect global signals
         if (this._installedChangedId)
-            Shell.AppSystem.get_default().disconnect(this._installedChangedId);
+            disconnect(Shell.AppSystem.get_default(), this._installedChangedId);
 
         if (this._favoritesChangedId)
-            AppFavorites.getAppFavorites().disconnect(this._favoritesChangedId);
+            disconnect(AppFavorites.getAppFavorites(),this._favoritesChangedId);
 
         if (this._iconsChangedId)
-            IconTheme.get_default().disconnect(this._iconsChangedId);
+            disconnect(IconTheme.get_default(), this._iconsChangedId);
 
         if (this._themeChangedId)
-            St.ThemeContext.get_for_stage(global.stage).disconnect(this._themeChangedId);
+            disconnect(St.ThemeContext.get_for_stage(global.stage), this._themeChangedId);
 
         if (this._overviewShownId)
-            Main.overview.disconnect(this._overviewShownId);
+            disconnect(Main.overview, this._overviewShownId);
 
         if (this._overviewHiddenId)
-            Main.overview.disconnect(this._overviewHiddenId);
+            disconnect(Main.overview, this._overviewHiddenId);
 
         if (this._overviewPageChangedId)
-            Main.overview.disconnect(this._overviewPageChangedId);
+            disconnect(Main.overview, this._overviewPageChangedId);
 
         if (this._hotCornersUpdatedId)
-            Main.layoutManager.disconnect(this._hotCornersUpdatedId);
+            disconnect(Main.layoutManager, this._hotCornersUpdatedId);
 
         // Unbind menu accelerator key
         Main.wm.removeKeybinding('panel-menu-keyboard-accelerator');

--- a/extension.js
+++ b/extension.js
@@ -135,7 +135,7 @@ function disconnect(obj, sig) {
             obj.disconnect(sig);
         }
     } catch (error) {
-        log('[GnoMenu] Failed to disconnect signal: ' + error);
+        global.log('[GnoMenu] Failed to disconnect signal: ' + error);
     }
 }
 
@@ -191,7 +191,7 @@ var CategoryListButton = class GnoMenu_CategoryListButton {
         this._ignoreHoverSelect = null;
 
         let style = "popup-menu-item popup-submenu-menu-item gnomenu-category-button";
-        this.actor = new St.Button({ reactive: true, style_class: style, x_fill: true, y_fill: true, x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE });
+        this.actor = new St.Button({ reactive: true, style_class: style, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER });
         this.actor._delegate = this;
         this.buttonbox = new St.BoxLayout({style_class: 'gnomenu-category-button-box'});
         let iconSize = 28;
@@ -212,17 +212,17 @@ var CategoryListButton = class GnoMenu_CategoryListButton {
             }
         }
 
-        this.label = new St.Label({ text: categoryNameText, style_class: 'gnomenu-category-button-label' });
-        this.buttonbox.add(this.label, {expand: true, x_fill: false, y_fill: false, x_align: St.Align.START, y_align: St.Align.MIDDLE});
+        this.label = new St.Label({ text: categoryNameText, style_class: 'gnomenu-category-button-label', x_expand: true, y_expand:true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER });
+        this.buttonbox.add_child(this.label);
         if (categoryIconName) {
-            this.iconWrapper = new St.Bin({style_class: 'gnomenu-category-button-icon'});
+            this.iconWrapper = new St.Bin({style_class: 'gnomenu-category-button-icon', x_expand: false, y_expand: false, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER});
             if (getCustIcon(categoryIconName)) {
                 this.icon = new St.Icon({gicon: getCustIcon(categoryIconName), icon_size: iconSize});
             } else {
                 this.icon = new St.Icon({icon_name: categoryIconName, icon_size: iconSize});
             }
             this.iconWrapper.add_actor(this.icon);
-            this.buttonbox.add(this.iconWrapper, {expand: false, x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE});
+            this.buttonbox.add_child(this.iconWrapper);
         }
 
         this.actor.set_child(this.buttonbox);
@@ -291,33 +291,33 @@ var ShortcutButton = class GnoMenu_ShortcutButton {
         this._app = app;
         this._type = appType;
         let style = "popup-menu-item gnomenu-shortcut-button";
-        this.actor = new St.Button({ reactive: true, style_class: style, x_align: St.Align.MIDDLE, y_align: St.Align.START });
+        this.actor = new St.Button({ reactive: true, style_class: style, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.START });
         this.actor._delegate = this;
         this._iconSize = (settings.get_int('shortcuts-icon-size') > 0) ? settings.get_int('shortcuts-icon-size') : 32;
 
         // appType 0 = application, appType 1 = place, appType 2 = recent
         if (appType == ApplicationType.APPLICATION) {
-            this.icon = app.create_icon_texture(this._iconSize);
-            this.label = new St.Label({ text: app.get_name(), style_class: 'gnomenu-application-grid-button-label' });
+            this.icon = new St.Bin({ child: app.create_icon_texture(this._iconSize), x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER});
+            this.label = new St.Label({ text: app.get_name(), style_class: 'gnomenu-application-grid-button-label', x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER });
         } else if (appType == ApplicationType.PLACE) {
             // Adjust 'places' symbolic icons by reducing their size
             // and setting a special class for button padding
             this._iconSize -= 4;
             this.actor.add_style_class_name('gnomenu-shortcut-symbolic-button');
-            this.icon = new St.Icon({gicon: app.icon, icon_size: this._iconSize});
+            this.icon = new St.Icon({gicon: app.icon, icon_size: this._iconSize, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER});
             if(!this.icon) this.icon = new St.Icon({icon_name: 'error', icon_size: this._iconSize, icon_type: St.IconType.FULLCOLOR});
-            this.label = new St.Label({ text: app.name, style_class: 'gnomenu-application-grid-button-label' });
+            this.label = new St.Label({ text: app.name, style_class: 'gnomenu-application-grid-button-label', x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER });
         } else if (appType == ApplicationType.RECENT) {
             let gicon = Gio.content_type_get_icon(app.mime);
             this.icon = new St.Icon({gicon: gicon, icon_size: this._iconSize});
-            if(!this.icon) this.icon = new St.Icon({icon_name: 'error', icon_size: this._iconSize, icon_type: St.IconType.FULLCOLOR});
-            this.label = new St.Label({ text: app.name, style_class: 'gnomenu-application-grid-button-label' });
+            if(!this.icon) this.icon = new St.Icon({icon_name: 'error', icon_size: this._iconSize, icon_type: St.IconType.FULLCOLOR, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER});
+            this.label = new St.Label({ text: app.name, style_class: 'gnomenu-application-grid-button-label', x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER });
         }
-        //this.label = new St.Label({ text: app.get_name(), style_class: 'gnomenu-shortcut-button-label' });
+        //this.label = new St.Label({ text: app.name, style_class: 'gnomenu-shortcut-button-label', x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER });
 
         this.buttonbox = new St.BoxLayout();
-        this.buttonbox.add(this.icon, {x_fill: false, y_fill: false, x_align: St.Align.START, y_align: St.Align.MIDDLE});
-        //this.buttonbox.add(this.label, {x_fill: false, y_fill: true, x_align: St.Align.START, y_align: St.Align.MIDDLE});
+        this.buttonbox.add_child(this.icon);
+        //this.buttonbox.add_child(this.label);
 
         this.actor.set_child(this.buttonbox);
 
@@ -401,23 +401,23 @@ var AppListButton = class GnoMenu_AppListButton {
         this._type = appType;
         this._stateChangedId = 0;
         let style = "popup-menu-item gnomenu-application-list-button";
-        this.actor = new St.Button({ reactive: true, style_class: style, x_align: St.Align.START, y_align: St.Align.MIDDLE});
+        this.actor = new St.Button({ reactive: true, style_class: style, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER});
         this.actor._delegate = this;
         this._iconSize = (settings.get_int('apps-list-icon-size') > 0) ? settings.get_int('apps-list-icon-size') : 28;
 
         // appType 0 = application, appType 1 = place, appType 2 = recent
         if (appType == ApplicationType.APPLICATION) {
-            this.icon = app.create_icon_texture(this._iconSize);
-            this.label = new St.Label({ text: app.get_name(), style_class: 'gnomenu-application-list-button-label' });
+            this.icon = new St.Bin({ child: app.create_icon_texture(this._iconSize), x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER});
+            this.label = new St.Label({ text: app.get_name(), style_class: 'gnomenu-application-list-button-label', x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER });
         } else if (appType == ApplicationType.PLACE) {
             this.icon = new St.Icon({gicon: app.icon, icon_size: this._iconSize});
-            if(!this.icon) this.icon = new St.Icon({icon_name: 'error', icon_size: this._iconSize, icon_type: St.IconType.FULLCOLOR});
-            this.label = new St.Label({ text: app.name, style_class: 'gnomenu-application-list-button-label' });
+            if(!this.icon) this.icon = new St.Icon({icon_name: 'error', icon_size: this._iconSize, icon_type: St.IconType.FULLCOLOR, x_align: Clutter.ActorAlign.END, y_align: Clutter.ActorAlign.END});
+            this.label = new St.Label({ text: app.name, style_class: 'gnomenu-application-list-button-label', x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER });
         } else if (appType == ApplicationType.RECENT) {
             let gicon = Gio.content_type_get_icon(app.mime);
             this.icon = new St.Icon({gicon: gicon, icon_size: this._iconSize});
-            if(!this.icon) this.icon = new St.Icon({icon_name: 'error', icon_size: this._iconSize, icon_type: St.IconType.FULLCOLOR});
-            this.label = new St.Label({ text: app.name, style_class: 'gnomenu-application-list-button-label' });
+            if(!this.icon) this.icon = new St.Icon({icon_name: 'error', icon_size: this._iconSize, icon_type: St.IconType.FULLCOLOR, x_align: Clutter.ActorAlign.END, y_align: Clutter.ActorAlign.END});
+            this.label = new St.Label({ text: app.name, style_class: 'gnomenu-application-list-button-label', x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER });
         }
 
         this._dot = new St.Widget({ style_class: 'app-well-app-running-dot',
@@ -426,15 +426,15 @@ var AppListButton = class GnoMenu_AppListButton {
                                     x_align: Clutter.ActorAlign.CENTER,
                                     y_align: Clutter.ActorAlign.END });
 
-        this._iconContainer = new St.BoxLayout({vertical: true});
+        this._iconContainer = new St.BoxLayout({vertical: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER});
         this._iconContainer.add_style_class_name('gnomenu-application-list-button-icon');
 
-        this._iconContainer.add(this.icon, {x_fill: false, y_fill: false, x_align: St.Align.END, y_align: St.Align.END});
-        this._iconContainer.add(this._dot, {x_fill: false, y_fill: false, x_align: St.Align.END, y_align: St.Align.END});
+        this._iconContainer.add_child(this.icon);
+        this._iconContainer.add_child(this._dot);
 
         this.buttonbox = new St.BoxLayout();
-        this.buttonbox.add(this._iconContainer, {x_fill: false, y_fill: false, x_align: St.Align.START, y_align: St.Align.MIDDLE});
-        this.buttonbox.add(this.label, {x_fill: false, y_fill: false, x_align: St.Align.START, y_align: St.Align.MIDDLE});
+        this.buttonbox.add_child(this._iconContainer);
+        this.buttonbox.add_child(this.label);
 
         this.actor.set_child(this.buttonbox);
 
@@ -554,40 +554,41 @@ var AppGridButton = class GnoMenu_AppGridButton {
             styleLabel += " no-categories";
         }
 
-        this.actor = new St.Button({reactive: true, style_class: styleButton, x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE});
+        this.actor = new St.Button({reactive: true, style_class: styleButton, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER});
         this.actor._delegate = this;
         this._iconSize = (settings.get_int('apps-grid-icon-size') > 0) ? settings.get_int('apps-grid-icon-size') : 64;
 
         // appType 0 = application, appType 1 = place, appType 2 = recent
         if (appType == ApplicationType.APPLICATION) {
-            this.icon = app.create_icon_texture(this._iconSize);
-            this.label = new St.Label({ text: app.get_name(), style_class: styleLabel });
+            this.icon = new St.Bin({ child: app.create_icon_texture(this._iconSize), x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER});
+            this.label = new St.Label({ text: app.get_name(), style_class: styleLabel, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER });
         } else if (appType == ApplicationType.PLACE) {
-            this.icon = new St.Icon({gicon: app.icon, icon_size: this._iconSize});
+            this.icon = new St.Icon({gicon: app.icon, icon_size: this._iconSize, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.START});
             if(!this.icon) this.icon = new St.Icon({icon_name: 'error', icon_size: this._iconSize, icon_type: St.IconType.FULLCOLOR});
-            this.label = new St.Label({ text: app.name, style_class: styleLabel });
+            this.label = new St.Label({ text: app.name, style_class: styleLabel, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER });
         } else if (appType == ApplicationType.RECENT) {
             let gicon = Gio.content_type_get_icon(app.mime);
-            this.icon = new St.Icon({gicon: gicon, icon_size: this._iconSize});
+            this.icon = new St.Icon({gicon: gicon, icon_size: this._iconSize, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.START});
             if(!this.icon) this.icon = new St.Icon({icon_name: 'error', icon_size: this._iconSize, icon_type: St.IconType.FULLCOLOR});
-            this.label = new St.Label({ text: app.name, style_class: styleLabel });
+            this.label = new St.Label({ text: app.name, style_class: styleLabel, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER });
         }
 
         this._dot = new St.Widget({ style_class: 'app-well-app-running-dot',
                                     layout_manager: new Clutter.BinLayout(),
-                                    x_expand: true, y_expand: true,
+                                    x_expand: true,
+                                    y_expand: true,
                                     x_align: Clutter.ActorAlign.CENTER,
                                     y_align: Clutter.ActorAlign.END });
 
         this.buttonbox = new St.BoxLayout({vertical: true});
-        this.buttonbox.add(this.icon, {x_fill: false, y_fill: false,x_align: St.Align.MIDDLE, y_align: St.Align.START});
+        this.buttonbox.add_child(this.icon);
         if(includeText){
             // Use pango to wrap label text
             //this.label.clutter_text.line_wrap_mode = Pango.WrapMode.WORD;
             //this.label.clutter_text.line_wrap = true;
-            this.buttonbox.add(this.label, {x_fill: false, y_fill: true,x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE});
+            this.buttonbox.add_child(this.label);
         }
-        this.buttonbox.add(this._dot, {x_fill: false, y_fill: false,x_align: St.Align.MIDDLE, y_align: St.Align.START});
+        this.buttonbox.add_child(this._dot);
         this.actor.set_child(this.buttonbox);
 
         // Connect signals
@@ -690,7 +691,7 @@ var GroupButton = class GnoMenu_GroupButton {
         this.buttonPressCallback = null;
         this.buttonReleaseCallback = null;
         let style = "popup-menu-item popup-submenu-menu-item";
-        this.actor = new St.Button({ reactive: true, style_class: style, x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE });
+        this.actor = new St.Button({ reactive: true, style_class: style, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER });
         this.actor.add_style_class_name(params.style_class);
 
         this.actor._delegate = this;
@@ -700,18 +701,18 @@ var GroupButton = class GnoMenu_GroupButton {
             this._iconSize = iconSize;
             // //this.icon = new St.Icon({icon_name: iconName, icon_size: iconSize, icon_type: St.IconType.SYMBOLIC});
             if (getCustIcon(iconName)) {
-                this.icon = new St.Icon({gicon: getCustIcon(iconName), icon_size: iconSize});
+                this.icon = new St.Icon({gicon: getCustIcon(iconName), icon_size: iconSize, x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
             } else {
-                this.icon = new St.Icon({icon_name: iconName, icon_size: iconSize});
+                this.icon = new St.Icon({icon_name: iconName, icon_size: iconSize, x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
             }
-            this.buttonbox.add(this.icon, {x_fill: false, y_fill: false,x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE});
+            this.buttonbox.add_child(this.icon);
         }
         if (labelText) {
-            this.label = new St.Label({ text: labelText, style_class: params.style_class+'-label' });
+            this.label = new St.Label({ text: labelText, style_class: params.style_class+'-label', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER });
             // Use pango to wrap label text
             //this.label.clutter_text.line_wrap_mode = Pango.WrapMode.WORD;
             //this.label.clutter_text.line_wrap = true;
-            this.buttonbox.add(this.label, {x_fill: false, y_fill: false, x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE});
+            this.buttonbox.add_child(this.label);
         }
         this.actor.set_child(this.buttonbox);
 
@@ -788,17 +789,17 @@ class GnoMenu_PanelButton extends PanelMenu.Button {
 
         // Add icon to button
         if (iconName) {
-            let icon = new St.Icon({ gicon: null, style_class: 'system-status-icon gnomenu-panel-menu-icon' });
-            this._box.add(icon, {expand: true, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+            let icon = new St.Icon({ gicon: null, style_class: 'system-status-icon gnomenu-panel-menu-icon', x_expand: true, y_expand: true, x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER });
+            this._box.add_child(icon);
             icon.icon_name = iconName;
         }
 
         // Add label to button
         if (nameText && nameText.length > 0) {
-                let label = new St.Label({ text: ' '+nameText});
+                let label = new St.Label({ text: ' '+nameText, expand: true, x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
                 let labelWrapper = new St.Bin();
                 labelWrapper.set_child(label);
-                this._box.add(labelWrapper, {expand: true, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+                this._box.add_child(labelWrapper);
         }
     }
 });
@@ -817,12 +818,12 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         // NOTE: can't get label to take using this method. Possible Gnome Shell bug?
         super._init(0.0, '');
 
-        this.actor.add_style_class_name('panel-button');
+        this.add_style_class_name('panel-button');
         this._bin = new St.Widget({ layout_manager: new Clutter.BinLayout() });
         this._box = new St.BoxLayout({ style_class: 'gnomenu-panel-menu-button' });
 
         this._bin.add_child(this._box);
-        this.actor.add_actor(this._bin);
+        this.add_actor(this._bin);
 
 
         // Add hotspot area 1px high at top of PanelMenuButton
@@ -837,8 +838,8 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
 
         // Add icon to button
         if (settings.get_boolean('use-panel-menu-icon')) {
-            let icon = new St.Icon({ gicon: null, style_class: 'system-status-icon gnomenu-panel-menu-icon' });
-            this._box.add(icon, {expand: true, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+            let icon = new St.Icon({ gicon: null, style_class: 'system-status-icon gnomenu-panel-menu-icon', x_expand: true, y_expand: true, x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER });
+            this._box.add_child(icon);
             if (settings.get_boolean('use-panel-menu-icon')) {
                 icon.icon_name = settings.get_strv('panel-menu-icon-name')[0];
             }
@@ -851,9 +852,9 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         }
         if (labelText && labelText.length > 0) {
             let label = new St.Label({ text: ' '+labelText});
-            let labelWrapper = new St.Bin();
+            let labelWrapper = new St.Bin({x_expand: true, y_expand:true, x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
             labelWrapper.set_child(label);
-            this._box.add(labelWrapper, {expand: true, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+            this._box.add_child(labelWrapper);
         }
 
         // Add arrow to button
@@ -862,7 +863,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         }
 
         this.menu.connect('open-state-changed', this._onOpenStateToggled.bind(this));
-        this.actor.connect('key-press-event', this._onPanelMenuKeyPress.bind(this));
+        this.connect('key-press-event', this._onPanelMenuKeyPress.bind(this));
         this.menu.actor.connect('key-press-event', this._onMenuKeyPress.bind(this));
 
         this.applicationsByCategory = {};
@@ -954,14 +955,14 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             this.thumbnailsBoxFiller.width = 0;
             this.workspacesWrapper.height = height;
             this.thumbnailsBox._createThumbnails();
-            this.thumbnailsBox.actor.set_position(1, 0); // position inside wrapper
+            this.thumbnailsBox.set_position(1, 0); // position inside wrapper
             if (settings.get_boolean('hide-workspaces')) {
                 this.workspacesWrapper.width = 0;
-                this.thumbnailsBox.actor.hide();
+                this.thumbnailsBox.hide();
                 this.workspacesWrapper.hide();
             } else {
-                this.workspacesWrapper.width = this.thumbnailsBox.actor.width;
-                this.thumbnailsBox.actor.show();
+                this.workspacesWrapper.width = this.thumbnailsBox.width;
+                this.thumbnailsBox.show();
                 this.workspacesWrapper.show();
             }
 
@@ -1633,7 +1634,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
                 let app = apps[0];
                 let appGridButton = new AppGridButton(app, appType, true);
                 let gridLayout = this.applicationsGridBox.layout_manager;
-				gridLayout.attach(appGridButton.actor, 0, 0, 1, 1);
+                gridLayout.attach(appGridButton.actor, 0, 0, 1, 1);
                 if (appGridButton.actor.get_stage()) {
                     let themeNode = appGridButton.actor.get_theme_node();
                     buttonMargin = {
@@ -1696,8 +1697,8 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         let gridWidth = (iconSize * this._appGridColumns) + gridBoxBorder.left + gridBoxBorder.right + gridBoxPadding.left + gridBoxPadding.right;
         if (_DEBUG_) global.log("gridbox width = "+gridWidth+" ["+this._appGridColumns+"] ["+gridBoxBorder.left+"]["+gridBoxBorder.right+"]["+gridBoxPadding.left+"]["+gridBoxPadding.right+"]");
         let scrollWidth = gridWidth + scrollBoxBorder.left + scrollBoxBorder.right + scrollBoxPadding.left + scrollBoxPadding.right;
-
         if (_DEBUG_) global.log("scrollbox width = "+scrollWidth+" minWidth = "+minWidth +" ["+scrollBoxBorder.left+"]["+scrollBoxBorder.right+"]["+scrollBoxPadding.left+"]["+scrollBoxPadding.right+"]");
+
         if (scrollWidth >= minWidth) {
             this.applicationsScrollBox.width = scrollWidth;
         } else {
@@ -1816,7 +1817,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
                            this.menu.close();
                         });
                         let gridLayout = this.applicationsGridBox.layout_manager;
-						gridLayout.attach(appGridButton.actor, column, rownum, 1, 1);
+                        gridLayout.attach(appGridButton.actor, column, rownum, 1, 1);
                         column ++;
                         if (column > this._appGridColumns-1) {
                             column = 0;
@@ -1900,7 +1901,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
                            this.menu.close();
                         });
                         let gridLayout = this.applicationsGridBox.layout_manager;
-						gridLayout.attach(appGridButton.actor, column, rownum, 1, 1);
+                        gridLayout.attach(appGridButton.actor, column, rownum, 1, 1);
                         column ++;
                         if (column > this._appGridColumns-1) {
                             column = 0;
@@ -1977,7 +1978,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
                            this.menu.close();
                         });
                         let gridLayout = this.applicationsGridBox.layout_manager;
-						gridLayout.attach(appGridButton.actor, column, rownum, 1, 1);
+                        gridLayout.attach(appGridButton.actor, column, rownum, 1, 1);
                         column ++;
                         if (column > this._appGridColumns-1) {
                             column = 0;
@@ -2052,8 +2053,8 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         if (thumbnail == null)
             return;
 
-        // let [x, y] = thumbnail.actor.get_transformed_position();
-        let [w, h] = thumbnail.actor.get_transformed_size();
+        // let [x, y] = thumbnail.get_transformed_position();
+        let [w, h] = thumbnail.get_transformed_size();
         let [borderTop, borderBottom] = this.thumbnailsBox.getIndicatorBorders();
 
         let vscroll = this.workspacesScrollBox.get_vscroll_bar();
@@ -2062,19 +2063,19 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         var scrollboxHeight = this.workspacesScrollBox.get_allocation_box().y2 - this.workspacesScrollBox.get_allocation_box().y1;
 
         var newScrollValue = currentScrollValue;
-        if (currentScrollValue > thumbnail.actor.y - borderTop) {
-            newScrollValue = thumbnail.actor.y - borderTop;
+        if (currentScrollValue > thumbnail.y - borderTop) {
+            newScrollValue = thumbnail.y - borderTop;
         }
 
-        if (scrollboxHeight + currentScrollValue < thumbnail.actor.y + h + borderBottom) {
-            newScrollValue = thumbnail.actor.y + h + borderBottom - scrollboxHeight;
+        if (scrollboxHeight + currentScrollValue < thumbnail.y + h + borderBottom) {
+            newScrollValue = thumbnail.y + h + borderBottom - scrollboxHeight;
         }
 
         vscroll.get_adjustment().set_value(newScrollValue);
     }
 
     _onWorkspacesScrolled(actor, event) {
-        global.log("WORKSPACE SCROLLED");
+        if (_DEBUG_) global.log("WORKSPACE SCROLLED");
         let activeWs = global.workspace_manager.get_active_workspace();
         let direction;
 
@@ -2648,7 +2649,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         this.categoriesWrapper = new St.BoxLayout({ style_class: 'gnomenu-categories-workspaces-wrapper', vertical: false});
 
         // categoriesScrollBox allows categories or workspaces to scroll vertically
-        this.categoriesScrollBox = new St.ScrollView({ reactive: true, x_fill: true, y_fill: false, y_align: St.Align.START, style_class: 'gnomenu-categories-workspaces-scrollbox' });
+        this.categoriesScrollBox = new St.ScrollView({ reactive: true, style_class: 'gnomenu-categories-workspaces-scrollbox', y_align: Clutter.ActorAlign.START });
         let vscrollCategories = this.categoriesScrollBox.get_vscroll_bar();
         vscrollCategories.connect('scroll-start', () => {
             this.menu.passEvents = true;
@@ -2660,11 +2661,11 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         this.categoriesScrollBox.set_mouse_scrolling(true);
 
         // selectedAppBox
-        this.selectedAppBox = new St.BoxLayout({ style_class: 'gnomenu-selected-app-box', vertical: false });
-        this.selectedAppTitle = new St.Label({ style_class: 'gnomenu-selected-app-title', text: "" });
-        this.selectedAppBox.add(this.selectedAppTitle, {expand: false, x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
-        this.selectedAppDescription = new St.Label({ style_class: 'gnomenu-selected-app-description', text: "" });
-        this.selectedAppBox.add(this.selectedAppDescription, {expand: false, x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+        this.selectedAppBox = new St.BoxLayout({ style_class: 'gnomenu-selected-app-box', vertical: false, x_expand: true, y_expand: true, x_align:Clutter.ActorAlign.END, y_align:Clutter.ActorAlign.CENTER });
+        this.selectedAppTitle = new St.Label({ style_class: 'gnomenu-selected-app-title', text: "", x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER });
+        this.selectedAppBox.add_child(this.selectedAppTitle);
+        this.selectedAppDescription = new St.Label({ style_class: 'gnomenu-selected-app-description', text: "", x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER });
+        this.selectedAppBox.add_child(this.selectedAppDescription);
 
         // UserGroupBox
         this.userGroupBox = new St.BoxLayout({ style_class: 'gnomenu-user-group-box' });
@@ -2674,7 +2675,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             userGroupButtonIconSize = 16;
 
         // Create 'recent' category button
-        this.recentCategory = new GroupButton( "folder-recent-symbolic", userGroupButtonIconSize, null, {style_class: 'gnomenu-user-group-button'});
+        this.recentCategory = new GroupButton( "folder-recent-symbolic", userGroupButtonIconSize, null, {style_class: 'gnomenu-user-group-button', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.recentCategory.setButtonEnterCallback(() => {
             this.recentCategory.actor.add_style_class_name('selected');
             this.selectedAppTitle.set_text(_('Recent'));
@@ -2705,7 +2706,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         });
 
         // Create 'webBookmarks' category button
-        this.webBookmarksCategory = new GroupButton( "web-browser-symbolic", userGroupButtonIconSize, null, {style_class: 'gnomenu-user-group-button'});
+        this.webBookmarksCategory = new GroupButton( "web-browser-symbolic", userGroupButtonIconSize, null, {style_class: 'gnomenu-user-group-button', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.webBookmarksCategory.setButtonEnterCallback(() => {
             this.webBookmarksCategory.actor.add_style_class_name('selected');
             this.selectedAppTitle.set_text(_('WebBookmarks'));
@@ -2735,8 +2736,8 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             }
         });
 
-        this.userGroupBox.add(this.recentCategory.actor, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
-        this.userGroupBox.add(this.webBookmarksCategory.actor, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+        this.userGroupBox.add_child(this.recentCategory.actor);
+        this.userGroupBox.add_child(this.webBookmarksCategory.actor);
 
         if (settings.get_boolean('hide-useroptions')) {
             this.userGroupBox.hide();
@@ -2757,10 +2758,10 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             viewModeAdditionalStyle = " no-useroptions";
         }
 
-        this.viewModeBoxWrapper = new St.BoxLayout({ style_class: 'gnomenu-view-mode-box-wrapper'+viewModeAdditionalStyle });
-        this.viewModeBox = new St.BoxLayout({ style_class: 'gnomenu-view-mode-box'+viewModeAdditionalStyle });
+        this.viewModeBoxWrapper = new St.BoxLayout({ style_class: 'gnomenu-view-mode-box-wrapper'+viewModeAdditionalStyle, x_align:Clutter.ActorAlign.START, y_align:Clutter.ActorAlign.CENTER });
+        this.viewModeBox = new St.BoxLayout({ style_class: 'gnomenu-view-mode-box'+viewModeAdditionalStyle, x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER });
 
-        this.toggleStartupAppsView = new GroupButton("view-toggle-apps-symbolic", viewModeButtonIconSize, null, {style_class: 'gnomenu-view-mode-button'});
+        this.toggleStartupAppsView = new GroupButton("view-toggle-apps-symbolic", viewModeButtonIconSize, null, {style_class: 'gnomenu-view-mode-button', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.toggleStartupAppsView.setButtonEnterCallback(() => {
             this.toggleStartupAppsView.actor.add_style_class_name('selected');
             this.selectedAppTitle.set_text(_('Toggle Startup Apps View'));
@@ -2787,7 +2788,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         });
 
 
-        this.toggleListGridView = new GroupButton(viewModeButtonIcon, viewModeButtonIconSize, null, {style_class: 'gnomenu-view-mode-button'});
+        this.toggleListGridView = new GroupButton(viewModeButtonIcon, viewModeButtonIconSize, null, {style_class: 'gnomenu-view-mode-button', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.toggleListGridView.setButtonEnterCallback(() => {
             this.toggleListGridView.actor.add_style_class_name('selected');
             this.selectedAppTitle.set_text(_('List-Grid View'));
@@ -2815,9 +2816,9 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             }
         });
 
-        this.viewModeBox.add(this.toggleStartupAppsView.actor, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
-        this.viewModeBox.add(this.toggleListGridView.actor, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
-        this.viewModeBoxWrapper.add(this.viewModeBox, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+        this.viewModeBox.add_child(this.toggleStartupAppsView.actor);
+        this.viewModeBox.add_child(this.toggleListGridView.actor);
+        this.viewModeBoxWrapper.add_child(this.viewModeBox);
 
         // SearchBox
         let searchEntryAdditionalStyle = "";
@@ -2840,15 +2841,19 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
 
         this._searchInactiveIcon = new St.Icon({ style_class: 'search-entry-icon', icon_name: 'edit-find-symbolic' });
         this._searchActiveIcon = new St.Icon({ style_class: 'search-entry-icon', icon_name: 'edit-clear-symbolic' });
-        this.searchBox = new St.BoxLayout({ style_class: 'gnomenu-search-box'+searchEntryAdditionalStyle });
+        this.searchBox = new St.BoxLayout({ style_class: 'gnomenu-search-box'+searchEntryAdditionalStyle, x_expand: true, y_expand: true, x_align:Clutter.ActorAlign.END, y_align:Clutter.ActorAlign.CENTER });
         this.searchEntry = new St.Entry({ name: 'gnomenuSearchEntry',
                                      style_class: 'search-entry gnomenu-search-entry'+searchEntryAdditionalStyle,
                                      hint_text: "",
                                      track_hover: true,
-                                     can_focus: true });
+                                     can_focus: true, 
+                                     x_expand: true,
+                                     y_expand: true,
+                                     x_align:Clutter.ActorAlign.START,
+                                     y_align:Clutter.ActorAlign.START });
 
         this.searchEntry.set_primary_icon(this._searchInactiveIcon);
-        this.searchBox.add(this.searchEntry, {expand: true, x_align:St.Align.START, y_align:St.Align.START});
+        this.searchBox.add_child(this.searchEntry);
         this.searchActive = false;
         this.searchEntryText = this.searchEntry.clutter_text;
         this.searchEntryText.connect('text-changed', this._onSearchTextChanged.bind(this));
@@ -2858,7 +2863,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
 
         // ShortcutsBox
         this.shortcutsBox = new St.BoxLayout({ style_class: 'gnomenu-shortcuts-box', vertical: true });
-        this.shortcutsScrollBox = new St.ScrollView({ x_fill: true, y_fill: false, y_align: St.Align.START, style_class: 'gnomenu-shortcuts-scrollbox' });
+        this.shortcutsScrollBox = new St.ScrollView({style_class: 'gnomenu-shortcuts-scrollbox', y_align: Clutter.ActorAlign.START });
         let vscrollShortcuts = this.shortcutsScrollBox.get_vscroll_bar();
         vscrollShortcuts.connect('scroll-start', () => {
             this.menu.passEvents = true;
@@ -2900,10 +2905,10 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             } else {
                 this.placesManager = new PlaceDisplay.PlacesManager(false);
             }
-            if (_DEBUG_) global.log("PanelMenuButton: _display - initialized PlacesManager")
+            if (_DEBUG_) global.log("PanelMenuButton: _display - initialized PlacesManager");
         } else {
             this.placesManager = null;
-            if (_DEBUG_) global.log("PanelMenuButton: _display - no PlacesManager")
+            if (_DEBUG_) global.log("PanelMenuButton: _display - no PlacesManager");
         }
 
         // Load Shortcuts Panel
@@ -2962,16 +2967,15 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         }
 
         // // Workspaces thumbnails Box and Wrapper
-        this.thumbnailsBoxFiller = new St.BoxLayout({ style_class: 'gnomenu-workspaces-filler', vertical: true });
+        this.thumbnailsBoxFiller = new St.BoxLayout({ style_class: 'gnomenu-workspaces-filler', vertical: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.START });
         // this.thumbnailsBox = new St.BoxLayout({ style_class: 'gnomenu-workspaces-filler', vertical: true });
         this.thumbnailsBox = new WorkspaceThumbnail.MyThumbnailsBox(settings, this.menu, this.thumbnailsBoxFiller);
-        this.workspacesWrapper = new St.BoxLayout({ style_class: 'gnomenu-workspaces-wrapper' });
-        this.workspacesWrapper.add(this.thumbnailsBoxFiller, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
-        // this.workspacesWrapper.add(this.thumbnailsBox, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
-        this.workspacesWrapper.add(this.thumbnailsBox.actor, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
+        this.workspacesWrapper = new St.BoxLayout({ style_class: 'gnomenu-workspaces-wrapper', x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.START });
+        this.workspacesWrapper.add_child(this.thumbnailsBoxFiller);
+        this.workspacesWrapper.add_child(this.thumbnailsBox);
 
         // // workspacesScrollBox allows workspace thumbnails to scroll vertically
-        this.workspacesScrollBox = new St.ScrollView({ reactive: true, x_fill: true, y_fill: false, y_align: St.Align.START, style_class: 'gnomenu-workspaces-scrollbox' });
+        this.workspacesScrollBox = new St.ScrollView({ reactive: true, style_class: 'gnomenu-workspaces-scrollbox', y_align: Clutter.ActorAlign.START });
         this.workspacesScrollBox.connect('scroll-event', this._onWorkspacesScrolled.bind(this));
         // let vscrollWorkspaces = this.workspacesScrollBox.get_vscroll_bar();
         // vscrollWorkspaces.connect('scroll-start', () => {
@@ -2985,7 +2989,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         // this.workspacesScrollBox.set_mouse_scrolling(true);
 
         // CategoriesBox
-        this.categoriesBox = new St.BoxLayout({ style_class: 'gnomenu-categories-box', vertical: true });
+        this.categoriesBox = new St.BoxLayout({ style_class: 'gnomenu-categories-box', vertical: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.START });
 
         // Initialize application categories
         this.applicationsByCategory = {};
@@ -3187,7 +3191,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         if (settings.get_enum('menu-layout') == MenuLayout.COMPACT)
             powerGroupButtonIconSize = 16;
 
-        this.systemRestart = new GroupButton('refresh-symbolic', powerGroupButtonIconSize, null, {style_class: 'gnomenu-power-group-button'});
+        this.systemRestart = new GroupButton('refresh-symbolic', powerGroupButtonIconSize, null, {style_class: 'gnomenu-power-group-button', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.systemRestart.setButtonEnterCallback(() => {
             this.systemRestart.actor.add_style_class_name('selected');
             this.selectedAppTitle.set_text(_('Restart Shell'));
@@ -3210,7 +3214,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             this.menu.close();
             global.reexec_self();
         });
-        this.systemSuspend = new GroupButton('suspend-symbolic', powerGroupButtonIconSize, null, {style_class: 'gnomenu-power-group-button'});
+        this.systemSuspend = new GroupButton('suspend-symbolic', powerGroupButtonIconSize, null, {style_class: 'gnomenu-power-group-button', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.systemSuspend.setButtonEnterCallback(() => {
             this.systemSuspend.actor.add_style_class_name('selected');
             this.selectedAppTitle.set_text(_('Suspend'));
@@ -3241,7 +3245,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
                     }
             });
         });
-        this.systemShutdown = new GroupButton('shutdown-symbolic', powerGroupButtonIconSize, null, {style_class: 'gnomenu-power-group-button'});
+        this.systemShutdown = new GroupButton('shutdown-symbolic', powerGroupButtonIconSize, null, {style_class: 'gnomenu-power-group-button', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.systemShutdown.setButtonEnterCallback(() => {
             this.systemShutdown.actor.add_style_class_name('selected');
             this.selectedAppTitle.set_text(_('Shutdown'));
@@ -3266,7 +3270,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             this.menu.close();
             this._session.ShutdownRemote();
         });
-        this.logoutUser = new GroupButton('user-logout-symbolic', powerGroupButtonIconSize, null, {style_class: 'gnomenu-power-group-button'});
+        this.logoutUser = new GroupButton('user-logout-symbolic', powerGroupButtonIconSize, null, {style_class: 'gnomenu-power-group-button', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.logoutUser.setButtonEnterCallback(() => {
             this.logoutUser.actor.add_style_class_name('selected');
             this.selectedAppTitle.set_text(_('Logout User'));
@@ -3289,7 +3293,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             this.menu.close();
             this._session.LogoutRemote(0);
         });
-        this.lockScreen = new GroupButton('user-lock-symbolic', powerGroupButtonIconSize, null, {style_class: 'gnomenu-power-group-button'});
+        this.lockScreen = new GroupButton('user-lock-symbolic', powerGroupButtonIconSize, null, {style_class: 'gnomenu-power-group-button', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.lockScreen.setButtonEnterCallback(() => {
             this.lockScreen.actor.add_style_class_name('selected');
             this.selectedAppTitle.set_text(_('Lock Screen'));
@@ -3314,14 +3318,14 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             Main.screenShield.lock(true);
         });
 
-        this.powerGroupBox.add(this.systemRestart.actor, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
-        this.powerGroupBox.add(this.systemSuspend.actor, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
-        this.powerGroupBox.add(this.systemShutdown.actor, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
-        this.powerGroupBox.add(this.logoutUser.actor, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
-        this.powerGroupBox.add(this.lockScreen.actor, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+        this.powerGroupBox.add_child(this.systemRestart.actor);
+        this.powerGroupBox.add_child(this.systemSuspend.actor);
+        this.powerGroupBox.add_child(this.systemShutdown.actor);
+        this.powerGroupBox.add_child(this.logoutUser.actor);
+        this.powerGroupBox.add_child(this.lockScreen.actor);
 
         // ApplicationsBox (ListView / GridView)
-        this.applicationsScrollBox = new St.ScrollView({ x_fill: true, y_fill: false, y_align: St.Align.START, style_class: 'vfade gnomenu-applications-scrollbox' });
+        this.applicationsScrollBox = new St.ScrollView({ style_class: 'vfade gnomenu-applications-scrollbox', y_align: Clutter.ActorAlign.START });
         this.applicationsScrollBox.connect('scroll-event', this._onAplicationsScrolled.bind(this));
         let vscrollApplications = this.applicationsScrollBox.get_vscroll_bar();
         vscrollApplications.connect('scroll-start', () => {
@@ -3331,23 +3335,23 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             this.menu.passEvents = false;
         });
 
-        this.applicationsListBox = new St.BoxLayout({ style_class: 'gnomenu-applications-list-box', vertical:true, x_expand:true});
-        this.applicationsGridBox = new St.Widget({ layout_manager: new Clutter.GridLayout(), reactive:true, style_class: 'gnomenu-applications-grid-box'});
+        this.applicationsListBox = new St.BoxLayout({ style_class: 'gnomenu-applications-list-box', vertical: true, x_expand: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.START});
+        this.applicationsGridBox = new St.Widget({ layout_manager: new Clutter.GridLayout(), reactive:true, style_class: 'gnomenu-applications-grid-box', x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.START});
         this.applicationsBoxWrapper = new St.BoxLayout({ style_class: 'gnomenu-applications-box-wrapper' });
-        this.applicationsBoxWrapper.add(this.applicationsGridBox, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
-        this.applicationsBoxWrapper.add(this.applicationsListBox, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
+        this.applicationsBoxWrapper.add_child(this.applicationsGridBox);
+        this.applicationsBoxWrapper.add_child(this.applicationsListBox);
         this.applicationsScrollBox.add_actor(this.applicationsBoxWrapper);
         this.applicationsScrollBox.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
         this.applicationsScrollBox.set_mouse_scrolling(true);
 
 
         // Extension Preferences
-        this.preferencesGroupBox = new St.BoxLayout({ style_class: 'gnomenu-preferences-group-box'});
+        this.preferencesGroupBox = new St.BoxLayout({ style_class: 'gnomenu-preferences-group-box', x_align:Clutter.ActorAlign.END, y_align:Clutter.ActorAlign.CENTER});
         let preferencesGroupButtonIconSize = 18;
         if (settings.get_enum('menu-layout') == MenuLayout.COMPACT)
             preferencesGroupButtonIconSize = 16;
 
-        this.extensionPreferences = new GroupButton('control-center-alt-symbolic', preferencesGroupButtonIconSize, null, {style_class: 'gnomenu-preferences-group-button'});
+        this.extensionPreferences = new GroupButton('control-center-alt-symbolic', preferencesGroupButtonIconSize, null, {style_class: 'gnomenu-preferences-group-button', x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.extensionPreferences.setButtonEnterCallback(() => {
             this.extensionPreferences.actor.add_style_class_name('selected');
             this.selectedAppTitle.set_text(_('Preferences'));
@@ -3370,7 +3374,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             Util.trySpawnCommandLine(PREFS_DIALOG);
             this.menu.close();
         });
-        this.preferencesGroupBox.add(this.extensionPreferences.actor, {x_fill:false, y_fill:false, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
+        this.preferencesGroupBox.add_child(this.extensionPreferences.actor);
 
 
         // Place boxes in proper containers. The order added determines position
@@ -3379,10 +3383,10 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         // topPane packs horizontally
         this.topPane.add(this.powerGroupBox);
         this.topPane.add(this.userGroupBox);
-        this.topPane.add(this.viewModeBoxWrapper, {x_align:St.Align.START, y_align:St.Align.MIDDLE});
-        this.topPane.add(this.searchBox, {expand: true, x_align:St.Align.END, y_align:St.Align.MIDDLE});
+        this.topPane.add_child(this.viewModeBoxWrapper);
+        this.topPane.add_child(this.searchBox);
 
-        this.categoriesWrapper.add(this.categoriesBox, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
+        this.categoriesWrapper.add_child(this.categoriesBox);
         this.categoriesScrollBox.add_actor(this.categoriesWrapper);
 
         if (settings.get_boolean('hide-categories')) {
@@ -3393,20 +3397,20 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
         }
 
         // middlePane packs horizontally
-        middlePane.add(this.shortcutsScrollBox, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
-        middlePane.add(this.categoriesScrollBox, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
-        middlePane.add(this.applicationsScrollBox, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
-        middlePane.add(this.workspacesScrollBox, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
-        // middlePane.add(this.workspacesWrapper, {x_fill:false, y_fill: false, x_align: St.Align.START, y_align: St.Align.START});
+        middlePane.add_child(this.shortcutsScrollBox);
+        middlePane.add_child(this.categoriesScrollBox);
+        middlePane.add_child(this.applicationsScrollBox);
+        middlePane.add_child(this.workspacesScrollBox);
+        // middlePane.add_child(this.workspacesWrapper);
 
         // bottomPane packs horizontally
-        let bottomPaneSpacer1 = new St.Label({text: '', style_class: 'gnomenu-spacer'});
+        let bottomPaneSpacer1 = new St.Label({text: '', style_class: 'gnomenu-spacer', x_expand: true, y_expand: true, x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
         this.bottomPane.add(this._dummyButton);
         this.bottomPane.add(this._dummyButton2);
         this.bottomPane.add(this._dummyBox1);
         this.bottomPane.add(this._dummyBox2);
-        this.bottomPane.add(bottomPaneSpacer1, {expand: true, x_align:St.Align.MIDDLE, y_align:St.Align.MIDDLE});
-        this.bottomPane.add(this.selectedAppBox, {expand: false, x_align:St.Align.END, y_align:St.Align.MIDDLE});
+        this.bottomPane.add_child(bottomPaneSpacer1);
+        this.bottomPane.add_child(this.selectedAppBox);
 
         let bShowPreferences = true;
         try {
@@ -3424,7 +3428,7 @@ class GnoMenu_PanelMenuButton extends PanelMenu.Button {
             global.log(err.message.toString());
         }
         if (bShowPreferences) {
-            this.topPane.add(this.preferencesGroupBox, {x_fill:false, y_fill: false, x_align:St.Align.END, y_align:St.Align.MIDDLE});
+            this.topPane.add_child(this.preferencesGroupBox);
         }
 
 
@@ -3463,7 +3467,7 @@ var GnoMenuButton = class GnoMenu_GnoMenuPanelButton {
         this._themeChangedId = St.ThemeContext.get_for_stage(global.stage).connect('changed', this._onStyleChanged.bind(this));
 
         // Connect gtk icontheme for when icons change
-        this._iconsChangedId = null; //IconTheme.get_default().connect('changed', this._onIconsChanged.bind(this));
+        this._iconsChangedId = IconTheme.get_default().connect('changed', this._onIconsChanged.bind(this));
 
         // Connect to AppSys for when new application installed
         this._installedChangedId = Shell.AppSystem.get_default().connect('installed-changed', this._onAppInstalledChanged.bind(this));
@@ -3489,7 +3493,7 @@ var GnoMenuButton = class GnoMenu_GnoMenuPanelButton {
 
     updateCornerPanel() {
         if (_DEBUG_) global.log("GnoMenuButton: updateCornerPanel");
-        if (Main.panel.actor.get_text_direction() == Clutter.TextDirection.RTL) {
+        if (Main.panel.get_text_direction() == Clutter.TextDirection.RTL) {
             Main.panel._leftCorner.setStyleParent(Main.panel._rightBox);
             Main.panel._rightCorner.setStyleParent(Main.panel._leftBox);
         } else {
@@ -3510,11 +3514,11 @@ var GnoMenuButton = class GnoMenu_GnoMenuPanelButton {
         // Disable or Enable Hot Corner
         if (settings.get_boolean('disable-activities-hotcorner')) {
             if (_DEBUG_) global.log("GnoMenuButton: updateHotCorner disabled hot corner");
-            if (corner && corner.actor) {
+            if (corner) {
                 // This is GS 3.8+ fallback corner. Need to hide actor
                 // to keep from triggering overview
                 if (_DEBUG_) global.log("GnoMenuButton: updateHotCorner corner & actor exist - HIDE");
-                corner.actor.hide();
+                corner.hide();
             } else {
                 // Need to destroy corner to remove pressure barrier
                 // to keep from triggering overview
@@ -3526,11 +3530,11 @@ var GnoMenuButton = class GnoMenu_GnoMenuPanelButton {
             }
         } else {
             if (_DEBUG_) global.log("GnoMenuButton: updateHotCorner enabled hot corner");
-            if (corner && corner.actor) {
+            if (corner) {
                 // This is Gs 3.8+ fallback corner. Need to show actor
                 // to trigger overview
                 if (_DEBUG_) global.log("GnoMenuButton: updateHotCorner corner & actor exist ");
-                corner.actor.show();
+                corner.show();
             } else {
                 // Need to create corner to setup pressure barrier
                 // to trigger overview
@@ -3797,7 +3801,7 @@ var GnoMenuButton = class GnoMenu_GnoMenuPanelButton {
             newStylesheet = Gio.file_new_for_path(themeDirectory + '/extensions/gno-menu/' + filename);
 
         if (!newStylesheet || !newStylesheet.query_exists(null)) {
-            if (_DEBUG_) global.log("GnoMenuButton: _chengeStylesheet Theme does_hotCornersUpdatedIdn't support gnomenu .. use default stylesheet");
+            if (_DEBUG_) global.log("GnoMenuButton: _changeStylesheet Theme doesn't support gnomenu .. use default stylesheet");
             let defaultStylesheet = Gio.File.new_for_path(Me.path + "/themes/default/" + filename);
             if (defaultStylesheet.query_exists(null)) {
                 newStylesheet = defaultStylesheet;
@@ -4040,7 +4044,7 @@ function enable() {
     if (hideDefaultActivitiesButton) {
         let button = Main.panel.statusArea['activities'];
         if (button != null) {
-            button.actor.hide();
+            button.hide();
         }
     }
 
@@ -4062,7 +4066,7 @@ function disable() {
     if (hideDefaultActivitiesButton) {
         let button = Main.panel.statusArea['activities'];
         if (button) {
-            button.actor.show();
+            button.show();
         }
     }
 
@@ -4074,4 +4078,3 @@ function disable() {
 function init() {
     Convenience.initTranslations();
 }
-

--- a/extension.js
+++ b/extension.js
@@ -119,7 +119,14 @@ function getCustIcon(icon_name) {
             return false;
         }
 
-}
+};
+
+// Workaround for (X)Wayland
+Gtk.IconTheme.get_default = function() {
+    let theme = new Gtk.IconTheme();
+    theme.set_custom_theme(St.Settings.get().gtk_icon_theme);
+    return theme;
+};
 
 /* =========================================================================
 /* name:    SearchWebBookmarks
@@ -4056,3 +4063,4 @@ function disable() {
 function init() {
     Convenience.initTranslations();
 }
+

--- a/extension.js
+++ b/extension.js
@@ -796,7 +796,7 @@ class GnoMenu_PanelButton extends PanelMenu.Button {
 
         // Add label to button
         if (nameText && nameText.length > 0) {
-                let label = new St.Label({ text: ' '+nameText, expand: true, x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
+                let label = new St.Label({ text: ' '+nameText, x_align:Clutter.ActorAlign.CENTER, y_align:Clutter.ActorAlign.CENTER});
                 let labelWrapper = new St.Bin();
                 labelWrapper.set_child(label);
                 this._box.add_child(labelWrapper);

--- a/metadata.json
+++ b/metadata.json
@@ -2,10 +2,10 @@
   "name": "Gno-Menu",
   "description": "Gno-Menu is a traditional styled full featured Gnome-Shell apps menu, that aims to offer all the essentials in a simple uncluttered intuitive interface.",
   "shell-version": [
-    "3.34"
+    "3.38"
   ],
   "uuid": "gnomenu@panacier.gmail.com",
   "url": "https://github.com/The-Panacea-Projects/Gnomenu",
   "gettext-domain": "gnomenu",
-  "version": 30
+  "version": 31
 }

--- a/myWorkspaceThumbnail.js
+++ b/myWorkspaceThumbnail.js
@@ -7,7 +7,6 @@ const Signals = imports.signals;
 const Background = imports.ui.background;
 const DND = imports.ui.dnd;
 const Main = imports.ui.main;
-const Tweener = imports.ui.tweener;
 const Workspace = imports.ui.workspace;
 const WorkspacesView = imports.ui.workspacesView;
 
@@ -51,37 +50,41 @@ class GnoMenu_MyPrimaryActorLayout extends Clutter.FixedLayout {
     }
 });
 
-var MyWindowClone = class {
-    constructor(realWindow, parentMenu) {
+var MyWindowClone = GObject.registerClass({
+    Signals: {
+        'drag-begin': {},
+        'drag-cancelled': {},
+        'drag-end': {},
+        'selected': { param_types: [GObject.TYPE_UINT] },
+    },
+}, class GnoMenu_MyWindowClone extends Clutter.Actor {
+    _init(realWindow, parentMenu) {
         this._parentMenu = parentMenu;
-        this.clone = new Clutter.Clone({ source: realWindow });
 
-        /* Can't use a Shell.GenericContainer because of DND and reparenting... */
-        this.actor = new Clutter.Actor({ layout_manager: new MyPrimaryActorLayout(this.clone),
-                                         reactive: true });
-        this.actor._delegate = this;
-        this.actor.add_child(this.clone);
+        let clone = new Clutter.Clone({ source: realWindow });
+        super._init({
+            layout_manager: new MyPrimaryActorLayout(clone),
+            reactive: true,
+        });
+        this._delegate = this;
+
+        this.add_child(clone);
         this.realWindow = realWindow;
         this.metaWindow = realWindow.meta_window;
 
-        this.clone._updateId = this.realWindow.connect('notify::position',
-                                                       this._onPositionChanged.bind(this));
-        this.clone._destroyId = this.realWindow.connect('destroy', () => {
+        clone._updateId = this.realWindow.connect('notify::position',
+                                                  this._onPositionChanged.bind(this));
+        clone._destroyId = this.realWindow.connect('destroy', () => {
             // First destroy the clone and then destroy everything
             // This will ensure that we never see it in the _disconnectSignals loop
-            this.clone.destroy();
+            clone.destroy();
             this.destroy();
         });
         this._onPositionChanged();
 
-        this.actor.connect('button-release-event',
-                           this._onButtonRelease.bind(this));
-        this.actor.connect('touch-event',
-                           this._onTouchEvent.bind(this));
+        this.connect('destroy', this._onDestroy.bind(this));
 
-        this.actor.connect('destroy', this._onDestroy.bind(this));
-
-        this._draggable = DND.makeDraggable(this.actor,
+        this._draggable = DND.makeDraggable(this,
                                             { restoreOnSuccess: true,
                                               dragActorMaxSize: Workspace.WINDOW_DND_SIZE,
                                               dragActorOpacity: Workspace.DRAGGING_WINDOW_OPACITY });
@@ -130,15 +133,12 @@ var MyWindowClone = class {
         if (actor.inDrag)
             return;
 
+        let parent = this.get_parent();
         let actualAbove = this.getActualStackAbove();
         if (actualAbove == null)
-            this.actor.lower_bottom();
+            parent.set_child_below_sibling(this, null);
         else
-            this.actor.raise(actualAbove);
-    }
-
-    destroy() {
-        this.actor.destroy();
+            parent.set_child_above_sibling(this, actualAbove);
     }
 
     addAttachedDialog(win) {
@@ -155,7 +155,7 @@ var MyWindowClone = class {
         clone._destroyId = realDialog.connect('destroy', () => {
             clone.destroy();
         });
-        this.actor.add_child(clone);
+        this.add_child(clone);
     }
 
     _updateDialogPosition(realDialog, cloneDialog) {
@@ -167,11 +167,11 @@ var MyWindowClone = class {
     }
 
     _onPositionChanged() {
-        this.actor.set_position(this.realWindow.x, this.realWindow.y);
+        this.set_position(this.realWindow.x, this.realWindow.y);
     }
 
     _disconnectSignals() {
-        this.actor.get_children().forEach(child => {
+        this.get_children().forEach(child => {
             let realWindow = child.source;
 
             realWindow.disconnect(child._updateId);
@@ -182,65 +182,67 @@ var MyWindowClone = class {
     _onDestroy() {
         this._disconnectSignals();
 
-        this.actor._delegate = null;
+        this._delegate = null;
 
         if (this.inDrag) {
             this.emit('drag-end');
             this.inDrag = false;
         }
-
-        this.disconnectAll();
     }
 
-    _onButtonRelease(actor, event) {
-        let button = event.get_button();
-        if (button == 3) { //right click
+    vfunc_button_press_event() {
+        return Clutter.EVENT_STOP;
+    }
+
+    vfunc_button_release_event(buttonEvent) {
+        if (buttonEvent.button == 3) {
+            // pass right-click event on allowing it to bubble up to thumbnailsBox
             return Clutter.EVENT_PROPAGATE;
         }
-
+        
         this._parentMenu.actor.grab_key_focus();
 
-        this.emit('selected', event.get_time());
+        this.emit('selected', buttonEvent.time);
 
         return Clutter.EVENT_STOP;
     }
 
-    _onTouchEvent(actor, event) {
-        if (event.type() != Clutter.EventType.TOUCH_END ||
-            !global.display.is_pointer_emulating_sequence(event.get_event_sequence()))
+    vfunc_touch_event(touchEvent) {
+        if (touchEvent.type != Clutter.EventType.TOUCH_END ||
+            !global.display.is_pointer_emulating_sequence(touchEvent.sequence))
             return Clutter.EVENT_PROPAGATE;
 
-        this.emit('selected', event.get_time());
+        this.emit('selected', touchEvent.time);
         return Clutter.EVENT_STOP;
     }
 
-    _onDragBegin(draggable, time) {
+    _onDragBegin(_draggable, _time) {
         this.inDrag = true;
         this.emit('drag-begin');
     }
 
-    _onDragCancelled(draggable, time) {
+    _onDragCancelled(_draggable, _time) {
         this.emit('drag-cancelled');
     }
 
-    _onDragEnd(draggable, time, snapback) {
+    _onDragEnd(_draggable, _time, _snapback) {
         this.inDrag = false;
 
         // We may not have a parent if DnD completed successfully, in
         // which case our clone will shortly be destroyed and replaced
         // with a new one on the target workspace.
-        if (this.actor.get_parent() != null) {
+        let parent = this.get_parent();
+        if (parent !== null) {
             if (this._stackAbove == null)
-                this.actor.lower_bottom();
+                parent.set_child_below_sibling(this, null);
             else
-                this.actor.raise(this._stackAbove);
+                parent.set_child_above_sibling(this, this._stackAbove);
         }
 
 
         this.emit('drag-end');
     }
-};
-Signals.addSignalMethods(MyWindowClone.prototype);
+});
 
 
 var ThumbnailState = {
@@ -257,22 +259,34 @@ var ThumbnailState = {
 /**
  * @metaWorkspace: a #Meta.Workspace
  */
-var MyWorkspaceThumbnail = class {
-    constructor(metaWorkspace, parentMenu) {
+var MyWorkspaceThumbnail = GObject.registerClass({
+    Properties: {
+        'collapse-fraction': GObject.ParamSpec.double(
+            'collapse-fraction', 'collapse-fraction', 'collapse-fraction',
+            GObject.ParamFlags.READWRITE,
+            0, 1, 0),
+        'slide-position': GObject.ParamSpec.double(
+            'slide-position', 'slide-position', 'slide-position',
+            GObject.ParamFlags.READWRITE,
+            0, 1, 0),
+    }
+}, class GnoMenu_MyWorkspaceThumbnail extends St.Widget {
+    _init(metaWorkspace, parentMenu) {
+        super._init({
+            clip_to_allocation: true,
+            style_class: 'workspace-thumbnail'
+        });
+        this._delegate = this;
         this._parentMenu = parentMenu;
         this.metaWorkspace = metaWorkspace;
         this.monitorIndex = Main.layoutManager.primaryIndex;
 
         this._removed = false;
 
-        this.actor = new St.Widget({ clip_to_allocation: true,
-                                     style_class: 'workspace-thumbnail' });
-        this.actor._delegate = this;
-
         this._contents = new Clutter.Actor();
-        this.actor.add_child(this._contents);
+        this.add_child(this._contents);
 
-        this.actor.connect('destroy', this._onDestroy.bind(this));
+        this.connect('destroy', this._onDestroy.bind(this));
 
         this._createBackground();
 
@@ -322,7 +336,7 @@ var MyWorkspaceThumbnail = class {
     }
 
     setPorthole(x, y, width, height) {
-        this.actor.set_size(width, height);
+        this.set_size(width, height);
         this._contents.set_position(-x, -y);
     }
 
@@ -339,31 +353,40 @@ var MyWorkspaceThumbnail = class {
 
         for (let i = 0; i < this._windows.length; i++) {
             let clone = this._windows[i];
-            let metaWindow = clone.metaWindow;
             if (i == 0) {
                 clone.setStackAbove(this._bgManager.backgroundActor);
             } else {
                 let previousClone = this._windows[i - 1];
-                clone.setStackAbove(previousClone.actor);
+                clone.setStackAbove(previousClone);
             }
         }
     }
 
-    set slidePosition(slidePosition) {
+    // eslint-disable-next-line camelcase
+    set slide_position(slidePosition) {
+        if (this._slidePosition == slidePosition)
+            return;
         this._slidePosition = slidePosition;
-        this.actor.queue_relayout();
+        this.notify('slide-position');
+        this.queue_relayout();
     }
 
-    get slidePosition() {
+    // eslint-disable-next-line camelcase
+    get slide_position() {
         return this._slidePosition;
     }
 
-    set collapseFraction(collapseFraction) {
+    // eslint-disable-next-line camelcase
+    set collapse_fraction(collapseFraction) {
+        if (this._collapseFraction == collapseFraction)
+            return;
         this._collapseFraction = collapseFraction;
-        this.actor.queue_relayout();
+        this.notify('collapse-fraction');
+        this.queue_relayout();
     }
 
-    get collapseFraction() {
+    // eslint-disable-next-line camelcase
+    get collapse_fraction() {
         return this._collapseFraction;
     }
 
@@ -393,7 +416,7 @@ var MyWorkspaceThumbnail = class {
             return;
         }
 
-        if (this._allWindows.indexOf(metaWin) == -1) {
+        if (!this._allWindows.includes(metaWin)) {
             let minimizedChangedId = metaWin.connect('notify::minimized',
                                                      this._updateMinimized.bind(this));
             this._allWindows.push(metaWin);
@@ -461,11 +484,6 @@ var MyWorkspaceThumbnail = class {
             this._doAddWindow(metaWin);
     }
 
-    destroy() {
-        if (this.actor)
-          this.actor.destroy();
-    }
-
     workspaceRemoved() {
         if (this._removed)
             return;
@@ -481,7 +499,7 @@ var MyWorkspaceThumbnail = class {
             this._allWindows[i].disconnect(this._minimizedChangedIds[i]);
     }
 
-    _onDestroy(actor) {
+    _onDestroy() {
         this.workspaceRemoved();
 
         if (this._bgManager) {
@@ -490,7 +508,6 @@ var MyWorkspaceThumbnail = class {
         }
 
         this._windows = [];
-        this.actor = null;
     }
 
     // Tests if @actor belongs to this workspace and monitor
@@ -522,15 +539,15 @@ var MyWorkspaceThumbnail = class {
         clone.connect('drag-end', () => {
             Main.overview.endWindowDrag(clone.metaWindow);
         });
-        clone.actor.connect('destroy', () => {
+        clone.connect('destroy', () => {
             this._removeWindowClone(clone.metaWindow);
         });
-        this._contents.add_actor(clone.actor);
+        this._contents.add_actor(clone);
 
         if (this._windows.length == 0)
             clone.setStackAbove(this._bgManager.backgroundActor);
         else
-            clone.setStackAbove(this._windows[this._windows.length - 1].actor);
+            clone.setStackAbove(this._windows[this._windows.length - 1]);
 
         this._windows.push(clone);
 
@@ -605,12 +622,21 @@ var MyWorkspaceThumbnail = class {
 
         return false;
     }
-};
-Signals.addSignalMethods(MyWorkspaceThumbnail.prototype);
+});
 
 
-var MyThumbnailsBox = GObject.registerClass(
-class GnoMenu_MyThumbnailsBox extends St.Widget {
+var MyThumbnailsBox = GObject.registerClass({
+    Properties: {
+        'indicator-y': GObject.ParamSpec.double(
+            'indicator-y', 'indicator-y', 'indicator-y',
+            GObject.ParamFlags.READWRITE,
+            0, Infinity, 0),
+        'scale': GObject.ParamSpec.double(
+            'scale', 'scale', 'scale',
+            GObject.ParamFlags.READWRITE,
+            0, Infinity, 0)
+    }
+}, class GnoMenu_MyThumbnailsBox extends St.Widget {
     _init(settings, parentMenu, filler) {
         this._mySettings = settings;
         this._parentMenu = parentMenu;
@@ -618,12 +644,13 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
 
         super._init({ reactive: true,
                       style_class: 'gnomenu-workspace-thumbnails',
-                      request_mode: Clutter.RequestMode.WIDTH_FOR_HEIGHT });
+                      request_mode: Clutter.RequestMode.WIDTH_FOR_HEIGHT, 
+                      x_align: Clutter.ActorAlign.START,
+                      y_align: Clutter.ActorAlign.START });
 
-         // this.actor = this;
-        this.actor._delegate = this;
+        this._delegate = this;
 
-        this.actor.add_style_class_name('gnomenu-workspaces-background');
+        this.add_style_class_name('gnomenu-workspaces-background');
 
         let indicator = new St.Bin({ style_class: 'workspace-thumbnail-indicator' });
 
@@ -706,12 +733,12 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
     }
 
     _activateThumbnailAtPoint(stageX, stageY, time) {
-        let [r, x, y] = this.transform_stage_point(stageX, stageY);
+        let [r_, x, y] = this.transform_stage_point(stageX, stageY);
 
         for (let i = 0; i < this._thumbnails.length; i++) {
-            let thumbnail = this._thumbnails[i]
-            let [w, h] = thumbnail.actor.get_transformed_size();
-            if (y >= thumbnail.actor.y && y <= thumbnail.actor.y + h) {
+            let thumbnail = this._thumbnails[i];
+            let [w, h] = thumbnail.get_transformed_size();
+            if (y >= thumbnail.y && y <= thumbnail.y + h) {
                 thumbnail.activate(time);
                 this._parentMenu.actor.grab_key_focus();
                 break;
@@ -798,14 +825,14 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
         if (this._dropPlaceholderPos == 0)
             targetBase = this._dropPlaceholder.y;
         else
-            targetBase = this._thumbnails[0].actor.y;
+            targetBase = this._thumbnails[0].y;
         let targetTop = targetBase - spacing - WORKSPACE_CUT_SIZE;
         let length = this._thumbnails.length;
         for (let i = 0; i < length; i ++) {
             // Allow the reorder target to have a 10px "cut" into
             // each side of the thumbnail, to make dragging onto the
             // placeholder easier
-            let [w, h] = this._thumbnails[i].actor.get_transformed_size();
+            let [w, h] = this._thumbnails[i].get_transformed_size();
             let targetBottom = targetBase + WORKSPACE_CUT_SIZE;
             let nextTargetBase = targetBase + h + spacing;
             let nextTargetTop =  nextTargetBase - spacing - ((i == length - 1) ? 0: WORKSPACE_CUT_SIZE);
@@ -876,7 +903,7 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
             // an old one which just became empty)
             let thumbnail = this._thumbnails[newWorkspaceIndex];
             this._setThumbnailState(thumbnail, ThumbnailState.NEW);
-            thumbnail.slidePosition = 1;
+            thumbnail.slide_position = 1;
 
             this._queueUpdateStates();
 
@@ -974,7 +1001,7 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
             thumbnail.setPorthole(this._porthole.x, this._porthole.y,
                                   this._porthole.width, this._porthole.height);
             this._thumbnails.push(thumbnail);
-            this.add_actor(thumbnail.actor);
+            this.add_actor(thumbnail);
 
             if (start > 0 && this._spliceIndex == -1) {
                 // not the initial fill, and not splicing via DND
@@ -992,7 +1019,7 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
 
         // The thumbnails indicator actually needs to be on top of the thumbnails
         if (this._indicator)
-            this._indicator.raise_top();
+            this.set_child_above_sibling(this._indicator, null);
 
         // Clear the splice index, we got the message
         this._spliceIndex = -1;
@@ -1023,7 +1050,10 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
     }
 
     set scale(scale) {
+        if (this._scale == scale)
+            return;
         this._scale = scale;
+        this.notify('scale');
         this.queue_relayout();
     }
 
@@ -1031,12 +1061,18 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
         return this._scale;
     }
 
-    set indicatorY(indicatorY) {
+    // eslint-disable-next-line camelcase
+    set indicator_y(indicatorY) {
+        if (this._indicatorY == indicatorY)
+            return;
+
         this._indicatorY = indicatorY;
+        this.notify('indicator-y');
         this.queue_relayout();
     }
 
-    get indicatorY() {
+    // eslint-disable-next-line camelcase
+    get indicator_y() {
         return this._indicatorY;
     }
 
@@ -1056,15 +1092,6 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
         }
     }
 
-    _tweenScale() {
-        Tweener.addTween(this,
-                         { scale: this._targetScale,
-                           time: RESCALE_ANIMATION_TIME,
-                           transition: 'easeOutQuad',
-                           onComplete: this._queueUpdateStates,
-                           onCompleteScope: this });
-    }
-
     _updateStates() {
         this._stateUpdateQueued = false;
 
@@ -1076,15 +1103,14 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
         this._iterateStateThumbnails(ThumbnailState.REMOVING, thumbnail => {
             this._setThumbnailState(thumbnail, ThumbnailState.ANIMATING_OUT);
 
-            Tweener.addTween(thumbnail,
-                             { slidePosition: 1,
-                               time: SLIDE_ANIMATION_TIME,
-                               transition: 'linear',
-                               onComplete: () => {
-                                   this._setThumbnailState(thumbnail, ThumbnailState.ANIMATED_OUT);
-                                   this._queueUpdateStates();
-                               }
-                             });
+            thumbnail.ease_property('slide-position', 1, {
+                duration: SLIDE_ANIMATION_TIME,
+                mode: Clutter.AnimationMode.LINEAR,
+                onComplete: () => {
+                    this._setThumbnailState(thumbnail, ThumbnailState.ANIMATED_OUT);
+                    this._queueUpdateStates();
+                }
+            });
         });
 
         // As long as things are sliding out, don't proceed
@@ -1094,25 +1120,28 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
         // Once that's complete, we can start scaling to the new size and collapse any removed thumbnails
         this._iterateStateThumbnails(ThumbnailState.ANIMATED_OUT, thumbnail => {
             this._setThumbnailState(thumbnail, ThumbnailState.COLLAPSING);
-            Tweener.addTween(thumbnail,
-                             { collapseFraction: 1,
-                               time: RESCALE_ANIMATION_TIME,
-                               transition: 'easeOutQuad',
-                               onComplete: () => {
-                                   this._stateCounts[thumbnail.state]--;
-                                   thumbnail.state = ThumbnailState.DESTROYED;
+            thumbnail.ease_property('collapse-fraction', 1, {
+                duration: RESCALE_ANIMATION_TIME,
+                mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+                onComplete: () => {
+                    this._stateCounts[thumbnail.state]--;
+                    thumbnail.state = ThumbnailState.DESTROYED;
 
-                                   let index = this._thumbnails.indexOf(thumbnail);
-                                   this._thumbnails.splice(index, 1);
-                                   thumbnail.destroy();
+                    let index = this._thumbnails.indexOf(thumbnail);
+                    this._thumbnails.splice(index, 1);
+                    thumbnail.destroy();
 
-                                   this._queueUpdateStates();
-                               }
-                             });
+                    this._queueUpdateStates();
+                }
+            });
         });
 
         if (this._pendingScaleUpdate) {
-            this._tweenScale();
+            this.ease_property('scale', this._targetScale, {
+                mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+                duration: RESCALE_ANIMATION_TIME,
+                onComplete: () => this._queueUpdateStates()
+            });
             this._pendingScaleUpdate = false;
         }
 
@@ -1123,14 +1152,13 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
         // And then slide in any new thumbnails
         this._iterateStateThumbnails(ThumbnailState.NEW, thumbnail => {
             this._setThumbnailState(thumbnail, ThumbnailState.ANIMATING_IN);
-            Tweener.addTween(thumbnail,
-                             { slidePosition: 0,
-                               time: SLIDE_ANIMATION_TIME,
-                               transition: 'easeOutQuad',
-                               onComplete: () => {
-                                   this._setThumbnailState(thumbnail, ThumbnailState.NORMAL);
-                               }
-                             });
+            thumbnail.ease_property('slide-position', 0, {
+                duration: SLIDE_ANIMATION_TIME,
+                mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+                onComplete: () => {
+                    this._setThumbnailState(thumbnail, ThumbnailState.NORMAL);
+                }
+            });
         });
     }
 
@@ -1202,7 +1230,7 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
     }
 
     vfunc_allocate(box, flags) {
-        this.set_allocation(box, flags);
+        this.set_allocation(box);
 
         let rtl = (Clutter.get_default_text_direction () == Clutter.TextDirection.RTL);
 
@@ -1320,8 +1348,8 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
             childBox.y1 = y1;
             childBox.y2 = y1 + portholeHeight;
 
-            thumbnail.actor.set_scale(roundedHScale, roundedVScale);
-            thumbnail.actor.allocate(childBox, flags);
+            thumbnail.set_scale(roundedHScale, roundedVScale);
+            thumbnail.allocate(childBox, flags);
 
             // We round the collapsing portion so that we don't get thumbnails resizing
             // during an animation due to differences in rounded, but leave the uncollapsed
@@ -1357,23 +1385,23 @@ class GnoMenu_MyThumbnailsBox extends St.Widget {
         if (thumbnail == null)
             return
 
-        if (thumbnail.actor == null)
-            return
-
         this._animatingIndicator = true;
         let indicatorThemeNode = this._indicator.get_theme_node();
+
+        // Workaround: In certain cases it returns null which is not good, at least make it return zero
+        if (indicatorThemeNode == null)
+            indicatorThemeNode = 0;
+
         let indicatorTopFullBorder = indicatorThemeNode.get_padding(St.Side.TOP) + indicatorThemeNode.get_border_width(St.Side.TOP);
         this.indicatorY = this._indicator.allocation.y1 + indicatorTopFullBorder;
-        Tweener.addTween(this,
-                         { indicatorY: thumbnail.actor.allocation.y1,
-                           time: WorkspacesView.WORKSPACE_SWITCH_TIME,
-                           transition: 'easeOutQuad',
-                           onComplete() {
-                               this._animatingIndicator = false;
-                               this._queueUpdateStates();
-                           },
-                           onCompleteScope: this
-                         });
+        this.ease_property('indicator-y', thumbnail.allocation.x1, {
+            progress_mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            duration: WorkspacesView.WORKSPACE_SWITCH_TIME,
+            onComplete: () => {
+                this._animatingIndicator = false;
+                this._queueUpdateStates();
+            }
+        });
     }
 
     getIndicatorBorders() {


### PR DESCRIPTION
With this pull request, GnoMenu should be fully working again on Gnome 3.38, but it's untested on older versions.

- St.Align is replaced with Clutter.ActorAlign.
- x_fill/y_fill properties are removed because they don't exist anymore and there's no replacement for them.
- Quick workaround to make it work also on Wayland, without refactoring the code. It should be still compatible with X.org.
- A function to make sure signals are disconnected properly, I applied privately this solution a while ago for some rare issues with signals, but don't know if it's still needed right now. I have left it in the code, just in case.
- Remove deprecated usage of object.actor, to make the extension more future-proof.
- myWorkspaceThumbnail.js is updated by borrowing some code from @passingthru67 's workspaces-to-dock extension.

Known issues that I can't figure why:
- a lot of icons aren't aligned properly
- the menu seems to crash, but only once. Just close and reopen it to fix it.
